### PR TITLE
tui: Fix panic when going to the welcome page

### DIFF
--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -92,7 +92,7 @@ impl App {
         self.context.current_page_id = page;
 
         let new_page: Box<dyn Page + Send> = match page {
-            AppPage::Welcome => Box::new(WelcomePage::default()),
+            AppPage::Welcome => Box::new(WelcomePage::new()),
             AppPage::DevicePage => Box::new(DevicePage::new()),
         };
 


### PR DESCRIPTION
We should use ::new() instead of ::default().
LMAO, 1 line fix

```rust
thread 'main' panicked at tui/src/pages/welcome.rs:162:46:
index out of bounds: the len is 0 but the index is 0
stack backtrace:
   0: rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::panicking::panic_bounds_check
   3: <antumbra::pages::welcome::WelcomePage as antumbra::pages::Page>::handle_input::{{closure}}
   4: tokio::runtime::park::CachedParkThread::block_on
   5: tokio::runtime::context::runtime::enter_runtime
   6: antumbra::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```