### PR TITLE
tui: Fix loader state to retain its state when switching pages

### DIFF
--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -6,6 +6,7 @@ use crate::pages::{DevicePage, Page, WelcomePage};
 use penumbra::da::DAFile;
 use ratatui::crossterm::event::{self, Event, KeyCode, KeyModifiers};
 use ratatui::{DefaultTerminal, Frame};
+use std::path::PathBuf;
 use std::{io::Result, time::Duration};
 
 #[derive(PartialEq, Clone, Copy, Default)]
@@ -17,7 +18,7 @@ pub enum AppPage {
 
 #[derive(Default)]
 pub struct AppCtx {
-    loader: Option<DAFile>,
+    loader: Option<Loader>,
     exit: bool,
     current_page_id: AppPage,
     next_page_id: Option<AppPage>
@@ -28,12 +29,47 @@ pub struct App {
     pub context: AppCtx,
 }
 
-impl AppCtx {
-    pub fn set_loader(&mut self, loader: DAFile) {
-        self.loader = Some(loader);
+pub struct Loader {
+    path: PathBuf,
+    file: DAFile
+}
+impl Loader {
+    pub fn new(path: PathBuf, file: DAFile) -> Self {
+        Self {
+            path,
+            file
+        }
     }
-    pub fn loader(&self) -> Option<&DAFile> {
+    pub fn file(&self) -> &DAFile {
+        &self.file
+    }
+    pub fn _path(&self) -> &PathBuf {
+        &self.path
+    }
+    pub fn loader_name(&self) -> Option<String> {
+        self.path.file_name()
+            .and_then(|name| name.to_str())
+            .map(|s| s.to_string())
+    }
+}
+
+impl AppCtx {
+    pub fn loader(&self) -> Option<&Loader> {
         self.loader.as_ref()
+    }
+    pub fn set_loader(&mut self, loader_path: PathBuf, loader_file: DAFile) {
+        if let Some(loader) = self.loader.as_mut() {
+            loader.path = loader_path;
+            loader.file = loader_file;
+        } else {
+            self.loader = Some(Loader::new(loader_path, loader_file));
+        }
+    }
+    pub fn loader_name(&self) -> String {
+        self.loader
+            .as_ref()
+            .and_then(|l| l.loader_name())
+            .unwrap_or("Unknown DA".to_string())
     }
     pub fn change_page(&mut self, page: AppPage) {
         self.next_page_id = Some(page);

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -43,11 +43,11 @@ impl Loader {
     pub fn file(&self) -> &DAFile {
         &self.file
     }
-    pub fn _path(&self) -> &PathBuf {
+    pub fn path(&self) -> &PathBuf {
         &self.path
     }
     pub fn loader_name(&self) -> Option<String> {
-        self.path.file_name()
+        self.path().file_name()
             .and_then(|name| name.to_str())
             .map(|s| s.to_string())
     }

--- a/tui/src/pages/device.rs
+++ b/tui/src/pages/device.rs
@@ -79,9 +79,8 @@ impl DevicePage {
 
                 let da_data: Vec<u8> = ctx
                     .loader()
-                    .map(|loader| loader.da_raw_data.as_slice())
-                    .ok_or_else(|| DeviceStatus::Error("No DA loader in context".to_string()))?
-                    .to_vec();
+                    .map(|loader| loader.file().da_raw_data.as_slice().to_vec())
+                    .ok_or_else(|| DeviceStatus::Error("No DA loader in context".to_string()))?;
 
                 let mut dev = Device::init(port, da_data)
                     .await

--- a/tui/src/pages/welcome.rs
+++ b/tui/src/pages/welcome.rs
@@ -35,7 +35,6 @@ pub struct WelcomePage {
     state: WelcomeState,
     actions: Vec<MenuAction>,
     selected_idx: usize,
-    loader_name: Option<String>,
 }
 
 impl WelcomePage {
@@ -70,9 +69,9 @@ impl Page for WelcomePage {
 
         // Loader info (show filename or None)
         let loader_text = ctx.loader()
-            .as_ref()
-            .map(|_| format!("Selected Loader: {}", self.loader_name.as_deref().unwrap_or("Unnamed DA")))
+            .map(|_| format!("Selected Loader: {}", ctx.loader_name()))
             .unwrap_or_else(|| "Selected Loader: None".to_string());
+
 
         let loader_paragraph = Paragraph::new(loader_text)
             .style(Style::default().fg(Color::Yellow))
@@ -121,14 +120,8 @@ impl Page for WelcomePage {
                             match fs::read(path) {
                                 Ok(raw_data) => match DAFile::parse_da(&raw_data) {
                                     Ok(da_file) => {
-                                        self.loader_name = Some(
-                                            path.file_name()
-                                                .and_then(|name| name.to_str())
-                                                .unwrap_or("Unnamed DA")
-                                                .to_string(),
-                                        );
+                                        ctx.set_loader(path.to_path_buf(), da_file);
                                         self.state = WelcomeState::Idle;
-                                        ctx.set_loader(da_file);
                                     }
                                     Err(err) => {
                                         unimplemented!("Error handling unimplemented: {:?}", err);


### PR DESCRIPTION
DA info, now persisted in `app.rs`, must be stored in the `Loader` struct, which includes the file `path` and a `file` field of type `DAFile` for further use in the core.