### PR TITLE
core: Implement custom errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "crossterm 0.29.0",
+ "derive_builder",
  "env_logger",
  "futures",
  "hex",
@@ -200,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.40"
+version = "1.2.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d05d92f4b1fd76aad469d46cdd858ca761576082cd37df81416691e50199fb"
+checksum = "ac9fe6cdbb24b6ade63616c0a0688e45bb56732262c158df3c0c4bea4ca47cb7"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -261,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -369,6 +370,37 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
  "syn",
 ]
 
@@ -486,14 +518,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0399f9d26e5191ce32c498bebd31e7a3ceabc2745f0ac54af3f335126c3f24b3"
+checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "fnv"
@@ -624,6 +656,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,6 +678,16 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "2.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.0",
+]
 
 [[package]]
 name = "indoc"
@@ -738,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.176"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libudev"
@@ -813,7 +861,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -889,6 +937,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,9 +1013,11 @@ dependencies = [
  "env_logger",
  "hex",
  "log",
+ "num_enum",
  "rusb",
  "serialport",
  "sha2",
+ "thiserror",
  "tokio",
  "tokio-serial",
 ]
@@ -984,6 +1056,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,9 +1075,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -1043,9 +1124,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.3"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+checksum = "4a52d8d02cacdb176ef4678de6c052efb4b3da14b78e4db683a4252762be5433"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1055,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
+checksum = "722166aa0d7438abbaa4d5cc2c649dac844e8c56d82fb3d33e9c34b5cd268fc6"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1066,9 +1147,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+checksum = "c3160422bbd54dd5ecfdca71e5fd59b7b8fe2b1697ab2baf64f6d05dcc66d298"
 
 [[package]]
 name = "rusb"
@@ -1109,7 +1190,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1161,9 +1242,9 @@ dependencies = [
 
 [[package]]
 name = "serialport"
-version = "4.7.3"
+version = "4.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acaf3f973e8616d7ceac415f53fc60e190b2a686fbcf8d27d0256c741c5007b"
+checksum = "21f60a586160667241d7702c420fc223939fb3c0bb8d3fac84f78768e8970dee"
 dependencies = [
  "bitflags 2.9.4",
  "cfg-if",
@@ -1173,9 +1254,10 @@ dependencies = [
  "libudev",
  "mach2",
  "nix 0.26.4",
+ "quote",
  "scopeguard",
  "unescaper",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1376,6 +1458,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,9 +1585,18 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1492,14 +1613,14 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.4",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
@@ -1522,19 +1643,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.4"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1545,9 +1666,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1557,9 +1678,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1569,9 +1690,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -1581,9 +1702,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1593,9 +1714,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1605,9 +1726,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1617,9 +1738,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1629,6 +1750,15 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "3"
 members = [
     "core",
     "tui"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,9 +11,11 @@ cipher = "0.4.4"
 env_logger = "0.11.8"
 hex = "0.4.3"
 log = "0.4.27"
+num_enum = "0.7.4"
 rusb = { version = "0.9.4", optional = true}
 serialport = "4.7.3"
 sha2 = "0.10.9"
+thiserror = "2.0.17"
 tokio = {version = "1.47.1", features = ["full"]}
 tokio-serial = "5.4.5"
 

--- a/core/src/connection/backend/mod.rs
+++ b/core/src/connection/backend/mod.rs
@@ -3,7 +3,6 @@
     SPDX-FileCopyrightText: 2025 Shomy
 */
 pub mod serial_backend;
-pub use serial_backend::SerialMTKPort;
 #[cfg(feature = "libusb")]
 pub mod libusb_backend;
 #[cfg(feature = "libusb")]

--- a/core/src/connection/port.rs
+++ b/core/src/connection/port.rs
@@ -3,8 +3,8 @@
     SPDX-FileCopyrightText: 2025 Shomy
 */
 
+use crate::error::Result;
 use std::fmt::Debug;
-use tokio::io::Result;
 
 pub const KNOWN_PORTS: &[(u16, u16)] = &[
     (0x0e8d, 0x0003), // Mediatek USB Port (BROM)

--- a/core/src/core/crypto/sej.rs
+++ b/core/src/core/crypto/sej.rs
@@ -186,7 +186,7 @@ impl<'a> SEJCrypto<'a> {
 
     async fn hw_aes128_cbc_encrypt(&mut self, data: &[u8], encrypt: bool, legacy: bool) -> Vec<u8> {
         self.sej_v3_init(encrypt, &HACC_CFG_1, legacy).await;
-        let ret = self.sej_run(&data).await;
+        let ret = self.sej_run(data).await;
         self.sej_terminate().await;
         ret
     }

--- a/core/src/core/seccfg.rs
+++ b/core/src/core/seccfg.rs
@@ -41,6 +41,12 @@ pub struct SecCfgV4 {
     algo: Option<SecCfgV4Algo>,
 }
 
+impl Default for SecCfgV4 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SecCfgV4 {
     pub fn new() -> Self {
         SecCfgV4 {

--- a/core/src/core/storage.rs
+++ b/core/src/core/storage.rs
@@ -2,7 +2,7 @@
     SPDX-License-Identifier: AGPL-3.0-or-later
     SPDX-FileCopyrightText: 2025 Shomy
 */
-use std::io::{Error, ErrorKind, Result};
+use crate::error::{Error, Result};
 
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -85,10 +85,7 @@ pub fn parse_gpt(data: &[u8], storage_type: StorageType) -> Result<Vec<Partition
     let sector_size = match sector_size {
         Some(size) => 512,
         None => {
-            return Err(Error::new(
-                ErrorKind::InvalidData,
-                "No valid GPT header found",
-            ));
+            return Err(Error::penumbra("No valid GPT header found"));
         }
     };
 
@@ -98,10 +95,7 @@ pub fn parse_gpt(data: &[u8], storage_type: StorageType) -> Result<Vec<Partition
     let entry_size = u32::from_le_bytes(hdr[84..88].try_into().unwrap());
 
     if entry_size as usize != 128 {
-        return Err(Error::new(
-            ErrorKind::InvalidData,
-            "Unsupported partition entry size",
-        ));
+        return Err(Error::penumbra("Unsupported partition entry size"));
     }
 
     let start_offset = (partition_entry_lba as usize) * sector_size;
@@ -126,10 +120,7 @@ pub fn parse_gpt(data: &[u8], storage_type: StorageType) -> Result<Vec<Partition
         let last_lba = u64::from_le_bytes(entry[40..48].try_into().unwrap());
 
         if last_lba < first_lba {
-            return Err(Error::new(
-                ErrorKind::InvalidData,
-                "Partition last_lba < first_lba",
-            ));
+            return Err(Error::io("Partition last_lba < first_lba"));
         }
 
         let part_size = (last_lba - first_lba + 1) * sector_size as u64;

--- a/core/src/da/da.rs
+++ b/core/src/da/da.rs
@@ -2,8 +2,8 @@
     SPDX-License-Identifier: AGPL-3.0-or-later
     SPDX-FileCopyrightText: 2025 Shomy
 */
+use crate::error::{Error, Result};
 use log::debug;
-use std::io::Error;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum DAType {
@@ -39,7 +39,7 @@ pub struct DAFile {
 }
 
 impl DAFile {
-    pub fn parse_da(raw_data: &[u8]) -> Result<DAFile, Error> {
+    pub fn parse_da(raw_data: &[u8]) -> Result<DAFile> {
         let hdr = &raw_data[..0x6C];
 
         let da_type = if &hdr[0..2] == b"\xDA\xDA" {
@@ -51,8 +51,7 @@ impl DAFile {
         };
 
         if da_type != DAType::Legacy && !hdr.windows(0x12).any(|w| w == b"MTK_DOWNLOAD_AGENT") {
-            return Err(Error::new(
-                std::io::ErrorKind::InvalidData,
+            return Err(Error::penumbra(
                 "Invalid DA file: Missing MTK_DOWNLOAD_AGENT signature",
             ));
         }

--- a/core/src/da/protocol.rs
+++ b/core/src/da/protocol.rs
@@ -4,16 +4,16 @@
 */
 use crate::connection::Connection;
 use crate::connection::port::ConnectionType;
-use tokio::io::Error;
+use crate::error::{Error, Result};
 
 #[async_trait::async_trait]
 pub trait DAProtocol: Send {
     // Main helpers
-    async fn upload_da(&mut self) -> Result<bool, Error>;
-    async fn boot_to(&mut self, addr: u32, data: &[u8]) -> Result<bool, Error>;
-    async fn send(&mut self, data: &[u8], datatype: u32) -> Result<bool, Error>;
-    async fn send_data(&mut self, data: &[u8]) -> Result<bool, Error>;
-    async fn get_status(&mut self) -> Result<u32, Error>;
+    async fn upload_da(&mut self) -> Result<bool>;
+    async fn boot_to(&mut self, addr: u32, data: &[u8]) -> Result<bool>;
+    async fn send(&mut self, data: &[u8], datatype: u32) -> Result<bool>;
+    async fn send_data(&mut self, data: &[u8]) -> Result<bool>;
+    async fn get_status(&mut self) -> Result<u32>;
     // FLASH operations
     // fn read_partition(&mut self, name: &str) -> Result<Vec<u8>, Error>;
     async fn read_flash(
@@ -21,7 +21,7 @@ pub trait DAProtocol: Send {
         addr: u64,
         size: usize,
         progress: &mut (dyn FnMut(usize, usize) + Send),
-    ) -> Result<Vec<u8>, Error>;
+    ) -> Result<Vec<u8>>;
 
     async fn write_flash(
         &mut self,
@@ -29,18 +29,18 @@ pub trait DAProtocol: Send {
         size: usize,
         data: &[u8],
         progress: &mut (dyn FnMut(usize, usize) + Send),
-    ) -> Result<(), Error>;
+    ) -> Result<()>;
 
-    async fn download(&mut self, part_name: String, data: &[u8]) -> Result<(), Error>;
+    async fn download(&mut self, part_name: String, data: &[u8]) -> Result<()>;
 
     // Memory
-    async fn read32(&mut self, addr: u32) -> Result<u32, Error>;
-    async fn write32(&mut self, addr: u32, value: u32) -> Result<(), Error>;
+    async fn read32(&mut self, addr: u32) -> Result<u32>;
+    async fn write32(&mut self, addr: u32, value: u32) -> Result<()>;
 
-    async fn get_usb_speed(&mut self) -> Result<u32, Error>;
+    async fn get_usb_speed(&mut self) -> Result<u32>;
     // fn set_usb_speed(&mut self, speed: u32) -> Result<(), Error>;
 
     // Connection
     fn get_connection(&mut self) -> &mut Connection;
-    fn set_connection_type(&mut self, conn_type: ConnectionType) -> Result<(), Error>;
+    fn set_connection_type(&mut self, conn_type: ConnectionType) -> Result<()>;
 }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,0 +1,500 @@
+/*
+    SPDX-License-Identifier: AGPL-3.0-or-later
+    SPDX-FileCopyrightText: 2025 Shomy
+*/
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    /// An error related to XFlash protocol (and its error codes)
+    #[error("XFlash error: {0}")]
+    XFlash(#[from] XFlashError),
+    /// Generic Protocol error
+    #[error("Protocol Error {0}")]
+    Protocol(String),
+    /// Connection specific error
+    #[error("Connection Error: {0}")]
+    Connection(String),
+    /// Error related to I/O operations
+    /// In particular with the connection backends
+    #[error("I/O Error: {0}")]
+    Io(String),
+    /// Generic error that happens in Penumbra, can
+    /// be used for anything
+    #[error("Penumbra Error: {0}")]
+    Penumbra(String),
+    /// Error that takes a status code and formats it as hex.
+    /// When dealing with statuses in general, use
+    /// this, unless a more specific implementation
+    /// is there (e.g. XFlash)
+    #[error("{ctx}: Status is 0x{status:X}")]
+    Status { ctx: String, status: u32 },
+}
+
+impl Error {
+    pub fn io<S: Into<String>>(msg: S) -> Self {
+        Error::Io(msg.into())
+    }
+
+    pub fn conn<S: Into<String>>(msg: S) -> Self {
+        Error::Connection(msg.into())
+    }
+
+    pub fn proto<S: Into<String>>(msg: S) -> Self {
+        Error::Protocol(msg.into())
+    }
+
+    pub fn penumbra<S: Into<String>>(msg: S) -> Self {
+        Error::Penumbra(msg.into())
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(value: std::io::Error) -> Self {
+        Error::penumbra(value.to_string())
+    }
+}
+
+/*
+    XFlash error codes work as follows:
+
+    There are four severity levels:
+    * Success (0 << 30, or 0x00000000)
+    * Info    (1 << 30, or 0x40000000)
+    * Warning (2 << 30, or 0x80000000)
+    * Error   (3 << 30, or 0xC0000000)
+
+    Then, follows the "domain" of this error code
+    relates to:
+    * Common     (1)
+    * Security   (2)
+    * Library    (3)
+    * Device/HW  (4)
+    * Host?      (5)
+    * BROM       (6)
+    * DA         (7)
+    * Preloader  (8)
+
+    Finally, the actual error code (0x01-...)
+
+    Example:
+    0xc0070004 => 0xC0000000 (Error) | 7 << 16 (domain) | 0x4 (code)
+*/
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Error, IntoPrimitive, TryFromPrimitive)]
+#[repr(u32)]
+pub enum XFlashErrorKind {
+    #[error("Generic error")]
+    Error = 0xc0010001,
+    #[error("Abort")]
+    Abort = 0xc0010002,
+    #[error("Unsupported command")]
+    UnsupportedCommand = 0xc0010003,
+    #[error("Unsupported devctrl code")]
+    UnsupportedCtrlCode = 0xc0010004,
+    #[error("Protocol error")]
+    ProtocolError = 0xc0010005,
+    #[error("Protocol buffer overflow")]
+    ProtocolBufferOverflow = 0xc0010006,
+    #[error("Insufficient buffer")]
+    InsufficientBuffer = 0xc0010007,
+    #[error("USB SCAN error")]
+    UsbScanError = 0xc0010008,
+    #[error("Invalid hsession")]
+    InvalidHSession = 0xc0010009,
+    #[error("Invalid session")]
+    InvalidSession = 0xc001000A,
+    #[error("Invalid stage")]
+    InvalidStage = 0xc001000B,
+    #[error("Not implemented")]
+    NotImplemented = 0xc001000C,
+    #[error("File not found")]
+    FileNotFound = 0xc001000D,
+    #[error("Open file error")]
+    OpenFileError = 0xc001000E,
+    #[error("Write file error")]
+    WriteFileError = 0xc001000F,
+    #[error("Read file error")]
+    ReadFileError = 0xc0010010,
+    #[error("Create File error / Unsupported Version")]
+    CreateFileErrorOrUnsupportedVersion = 0xc0010011, // In XML these two errors are separated
+
+    // Security
+    #[error("SEC: Rom info not found")]
+    RomInfoNotFound = 0xc0020001,
+    #[error("SEC: Cust name not found")]
+    CustNameNotFound = 0xc0020002,
+    #[error("SEC: Device not supported")]
+    DeviceNotSupported = 0xc0020003,
+    #[error("SEC: Download forbidden (region is not whitelisted)")]
+    DlForbidden = 0xc0020004,
+    #[error("SEC: Image too large")]
+    ImgTooLarge = 0xc0020005,
+    #[error("SEC: Preloader verify failed")]
+    PlVerifyFailed = 0xc0020006,
+    #[error("SEC: Image verify failed")]
+    ImageVerifyFailed = 0xc0020007,
+    #[error("SEC: Hash operation failed")]
+    HashOperationFailed = 0xc0020008,
+    #[error("SEC: Hash binding check failed")]
+    HashBindingCheckFailed = 0xc0020009,
+    #[error("SEC: Invalid buffer")]
+    InvalidBuf = 0xc002000a,
+    #[error("SEC: Binding hash not available")]
+    BindingHashNotAvailable = 0xc002000b,
+    #[error("SEC: Write data not allowed (region is not whitelisted)")]
+    WriteDataNotAllowed = 0xc002000c,
+    #[error("SEC: Format not allowed (region is not whitelisted)")]
+    FormatNotAllowed = 0xc002000d,
+    #[error("SEC: SV5 public key auth failed")]
+    Sv5PubKeyAuthFailed = 0xc002000e,
+    #[error("SEC: SV5 hash verify failed")]
+    Sv5HashVerifyFailed = 0xc002000f,
+    #[error("SEC: SV5 RSA operation failed")]
+    Sv5RsaOpFailed = 0xc0020010,
+    #[error("SEC: SV5 RSA verify failed")]
+    Sv5RsaVerifyFailed = 0xc0020011,
+    #[error("SEC: SV5 GFH not found")]
+    Sv5GfhNotFound = 0xc0020012,
+    #[error("SEC: Invalid cert1")]
+    Cert1Invalid = 0xc0020013,
+    #[error("SEC: Invalid cert2")]
+    Cert2Invalid = 0xc0020014,
+    #[error("SEC: Image header invalid")]
+    ImghdrInvalid = 0xc0020015,
+    #[error("SEC: Signature size invalid")]
+    SigSizeInvalid = 0xc0020016,
+    #[error("SEC: RSA PSS operation failed")]
+    RsaPssOpFailed = 0xc0020017,
+    #[error("SEC: Certificate authentication failed")]
+    CertAuthFailed = 0xc0020018,
+    #[error("SEC: Public key auth mismatch N size")]
+    PubKeyAuthMismatchNSize = 0xc0020019,
+    #[error("SEC: Public key auth mismatch E size")]
+    PubKeyAuthMismatchESize = 0xc002001a,
+    #[error("SEC: Public key auth mismatch N")]
+    PubKeyAuthMismatchN = 0xc002001b,
+    #[error("SEC: Public key auth mismatch E")]
+    PubKeyAuthMismatchE = 0xc002001c,
+    #[error("SEC: Public key auth mismatch hash")]
+    PubKeyAuthMismatchHash = 0xc002001d,
+    #[error("SEC: Certificate object not found")]
+    CertObjNotFound = 0xc002001e,
+    #[error("SEC: Certificate OID not found")]
+    CertOidNotFound = 0xc002001f,
+    #[error("SEC: Certificate out of range")]
+    CertOutOfRange = 0xc0020020,
+    #[error("SEC: OID doesn't match")]
+    OidDoesntMatch = 0xc0020021,
+    #[error("SEC: Length doesn't match")]
+    LengthDoesntMatch = 0xc0020022,
+    #[error("SEC: ASN1 unknown operation")]
+    Asn1UnknownOp = 0xc0020023,
+    #[error("SEC: OID index out of range")]
+    OidIndexOutOfRange = 0xc0020024,
+    #[error("SEC: OID too large")]
+    OidTooLarge = 0xc0020025,
+    #[error("SEC: Public key size mismatch")]
+    PubKeySizeMismatch = 0xc0020026,
+    #[error("SEC: SWID mismatch")]
+    SwidMismatch = 0xc0020027,
+    #[error("SEC: Hash size mismatch")]
+    HashSizeMismatch = 0xc0020028,
+    #[error("SEC: Image header type mismatch")]
+    ImghdrTypeMismatch = 0xc0020029,
+    #[error("SEC: Image type mismatch")]
+    ImgTypeMismatch = 0xc002002a,
+    #[error("SEC: Image header hash verify failed")]
+    ImghdrHashVerifyFailed = 0xc002002b,
+    #[error("SEC: Image hash verify failed")]
+    ImgHashVerifyFailed = 0xc002002c,
+    #[error("SEC: Anti rollback violation")]
+    AntiRollbackViolation = 0xc002002d,
+    #[error("SEC: SECCFG not found")]
+    SeccfgNotFound = 0xc002002e,
+    #[error("SEC: SECCFG magic is incorrect")]
+    SeccfgMagicIncorrect = 0xc002002f,
+    #[error("SEC: SECCFG is invalid")]
+    SeccfgInvalid = 0xc0020030,
+    #[error("SEC: Cipher mode is invalid")]
+    CipherModeInvalid = 0xc0020031,
+    #[error("SEC: Cipher key is invalid")]
+    CipherKeyInvalid = 0xc0020032,
+    #[error("SEC: Cipher data unaligned")]
+    CipherDataUnaligned = 0xc0020033,
+    #[error("SEC: GFH file info not found")]
+    GfhFileInfoNotFound = 0xc0020034,
+    #[error("SEC: GFH anti clone not found")]
+    GfhAntiCloneNotFound = 0xc0020035,
+    #[error("SEC: GFH sec config not found")]
+    GfhSecCfgNotFound = 0xc0020036,
+    #[error("SEC: Unsupported source type")]
+    UnsupportedSourceType = 0xc0020037,
+    #[error("SEC: Cust name mismatch")]
+    CustNameMismatch = 0xc0020038,
+    #[error("SEC: Invalid address")]
+    InvalidAddress = 0xc0020039,
+    #[error("SEC: Certificate version not synced")]
+    CertificateVersionNotSynced = 0xc0020040,
+    #[error("SEC: Signature not synced")]
+    SignatureNotSynced = 0xc0020041,
+    #[error("SEC: Ext AllInOne Signature rejected")]
+    ExtAllInOneSignatureRejected = 0xc0020042,
+    #[error("SEC: Ext AllInOne Signature missing")]
+    ExtAllInOneSignatureMissing = 0xc0020043,
+    #[error("SEC: Communication key is not set")]
+    CommKeyIsNotSet = 0xc0020044,
+    #[error("SEC: Device info check failed")]
+    DevInfoCheckFailed = 0xc0020045,
+    #[error("SEC: Boot image count overflow")]
+    BootimgCountOverflow = 0xc0020046,
+    #[error("SEC: Signature not found")]
+    SignatureNotFound = 0xc0020047,
+    #[error("SEC: Boot image special handle")]
+    BootimgSpecialHandle = 0xc0020048,
+    #[error("SEC: Remote security policy disabled")]
+    RemoteSecurityPolicyDisabled = 0xc0020049,
+    #[error("SEC: RSA OAEP failed")]
+    RsaOaepFailed = 0xc002004A,
+    #[error("SEC: Insufficient buffer")]
+    InsufficientBuffer2 = 0xc002004B,
+    #[error("SEC: DA Anti-Rollback error. DA version less than OTP version.")]
+    DaAntiRollbackError = 0xc002004C,
+    #[error("SEC: Get OTP value failed")]
+    GetOtpValueFailed = 0xc002004D,
+    #[error("SEC: Invalid unit size")]
+    InvalidUnitSize = 0xc002004E,
+    #[error("SEC: Invalid group index")]
+    InvalidGroupIdx = 0xc002004F,
+    #[error("SEC: Image version overflow")]
+    ImgVersionOverflow = 0xc0020050,
+    #[error("SEC: OTP table not initialized")]
+    OtpTableNotInitialized = 0xc0020051,
+    #[error("SEC: Invalid partition name")]
+    InvalidPartitionName = 0xc0020052,
+    #[error("SEC: DA version Anti-Rollback error")]
+    DaVersionAntiRollbackError = 0xc0020053,
+    #[error("SEC: Invalid message size")]
+    InvalidMsgSize = 0xc0020054,
+    #[error("SEC: Security level unsupported")]
+    SecurityLevelUnsupported = 0xc0020055,
+    #[error("SEC: Security level mismatch")]
+    SecurityLevelMismatch = 0xc0020056,
+    #[error("SEC: Fault injection error")]
+    FaultInjectionError = 0xc0020057,
+    #[error("SEC: Public key hash group is invalid.")]
+    PubKeyHashGroupInvalid = 0xc0020058,
+    #[error("SEC: Security level too large")]
+    SecurityLevelTooLarge = 0xc0020059,
+    #[error("SEC: Security config is formatted")]
+    SecurityConfigIsFormatted = 0xc002005a,
+    #[error("SEC: Security config unknown error")]
+    SecurityConfigUnknownError = 0xc002005b,
+    #[error("SEC: Failed getting seccfg lockstate")]
+    LockstateSeccfgFailed = 0xc002005c,
+    #[error("SEC: Failed getting custom lockstate")]
+    LockstateCustomFailed = 0xc002005d,
+    #[error("SEC: Lockstate is inconsistent")]
+    LockstateInconsistent = 0xc002005e,
+
+    // Library
+    #[error("Library: Scatter file invalid")]
+    ScatterFileInvalid = 0xc0030001,
+    #[error("Library: DA file invalid")]
+    DaFileInvalid = 0xc0030002,
+    #[error("Library: DA selection error")]
+    DaSelectionError = 0xc0030003,
+    #[error("Library: Preloader invalid")]
+    PreloaderInvalid = 0xc0030004,
+    #[error("Library: EMI header invalid")]
+    EmiHdrInvalid = 0xc0030005,
+    #[error("Library: Storage mismatch")]
+    StorageMismatch = 0xc0030006,
+    #[error("Library: Invalid parameters")]
+    InvalidParameters = 0xc0030007,
+    #[error("Library: Invalid GPT")]
+    InvalidGpt = 0xc0030008,
+    #[error("Library: Invalid PMT")]
+    InvalidPmt = 0xc0030009,
+    #[error("Library: Layout changed")]
+    LayoutChanged = 0xc003000a,
+    #[error("Library: Invalid format parameter")]
+    InvalidFormatParam = 0xc003000b,
+    #[error("Library: Unknown storage section type")]
+    UnknownStorageSectionType = 0xc003000c,
+    #[error("Library: Unknown scatter field")]
+    UnknownScatterField = 0xc003000d,
+    #[error("Library: Partition table doesn't exist")]
+    PartitionTblDoesntExist = 0xc003000e,
+    #[error("Library: Scatter HW chip ID mismatch")]
+    ScatterHwChipIdMismatch = 0xc003000f,
+    #[error("Library: SEC certificate file not found")]
+    SecCertFileNotFound = 0xc0030010,
+    #[error("Library: SEC authentication file not found")]
+    SecAuthFileNotFound = 0xc0030011,
+    #[error("Library: SEC authentication file needed")]
+    SecAuthFileNeeded = 0xc0030012,
+    #[error("Library: EMI container file not found")]
+    EmiContainerFileNotFound = 0xc0030013,
+    #[error("Library: Scatter file not found")]
+    ScatterFileNotFound = 0xc0030014,
+    #[error("Library: XML file operation error")]
+    XmlFileOpError = 0xc0030015,
+    #[error("Library: Unsupported page size")]
+    UnsupportedPageSize = 0xc0030016,
+    #[error("Library: EMI info length offset invalid")]
+    EmiInfoLengthOffsetInvalid = 0xc0030017,
+    #[error("Library: EMI info length invalid")]
+    EmiInfoLengthInvalid = 0xc0030018,
+
+    // Device (Storage, DRAM, eFuses)
+    #[error("Device: Unsupported operation")]
+    UnsupportedOperation = 0xc0040001,
+    #[error("Device: Thread error")]
+    ThreadError = 0xc0040002,
+    #[error("Device: Checksum error")]
+    ChecksumError = 0xc0040003,
+    #[error("Device: Unknown sparse image format")]
+    UnknownSparse = 0xc0040004,
+    #[error("Device: Unknown sparse chunk type")]
+    UnknownSparseChunkType = 0xc0040005,
+    #[error("Device: Partition not found")]
+    PartitionNotFound = 0xc0040006,
+    #[error("Device: Failed to read partition table")]
+    ReadParttblFailed = 0xc0040007,
+    #[error("Device: Exceeded maximum partition number")]
+    ExceededMaxPartitionNumber = 0xc0040008,
+    #[error("Device: Unknown storage type")]
+    UnknownStorageType = 0xc0040009,
+    #[error("Device: DRAM test failed")]
+    DramTestFailed = 0xc004000A,
+    #[error("Device: Exceeded available range")]
+    ExceedAvailableRange = 0xc004000b,
+    #[error("Device: Failed to write sparse image")]
+    WriteSparseImageFailed = 0xc004000c,
+    #[error("Device: MMC error")]
+    MmcError = 0xc0040030,
+    #[error("Device: NAND error")]
+    NandError = 0xc0040040,
+    #[error("Device: NAND operation in progress")]
+    NandInProgress = 0xc0040041,
+    #[error("Device: NAND timeout")]
+    NandTimeout = 0xc0040042,
+    #[error("Device: NAND bad block")]
+    NandBadBlock = 0xc0040043,
+    #[error("Device: NAND erase failed")]
+    NandEraseFailed = 0xc0040044,
+    #[error("Device: NAND page program failed")]
+    NandPageProgramFailed = 0xc0040045,
+    #[error("Device: EMI setting version error")]
+    EmiSettingVersionError = 0xc0040050,
+    #[error("Device: UFS error")]
+    UfsError = 0xc0040060,
+    #[error("Device: DA OTP not supported")]
+    DaOtpNotSupported = 0xc0040100,
+    #[error("Device: DA OTP lock failed")]
+    DaOtpLockFailed = 0xc0040102,
+
+    // eFuses
+    #[error("eFuse: Unknown error")]
+    EfuseUnknownError = 0xc0040200,
+    #[error("eFuse: Write timeout without verification")]
+    EfuseWriteTimeoutWithoutVerify = 0xc0040201,
+    #[error("eFuse: fuse blown")]
+    EfuseBlown = 0xc0040202,
+    #[error("eFuse: Revert bit is set")]
+    EfuseRevertBit = 0xc0040203,
+    #[error("eFuse: fuse is partly blown, needs to be blown again")]
+    EfuseBlownPartly = 0xc0040204,
+    #[error("eFuse: argument is invalid")]
+    EfuseInvalidArgument = 0xc0040205,
+    #[error("eFuse: fuse value is not zero")]
+    EfuseValueIsNotZero = 0xc0040206,
+    #[error("eFuse: fuse blown with incorrect data")]
+    EfuseBlownIncorrectData = 0xc0040207,
+    #[error("eFuse: Fuse is broken")]
+    EfuseBroken = 0xc0040208,
+    #[error("eFuse: Eror during blow operation")]
+    EfuseBlowError = 0xc0040209,
+    #[error("eFuse: Error while unlocking BPKEY")]
+    EfuseUnlockBpkeyError = 0xc004020A,
+    #[error("eFuse: Failed to create list")]
+    EfuseCreateListError = 0xc004020B,
+    #[error("eFuse: Failed to write to register")]
+    EfuseWriteRegisterError = 0xc004020C,
+    #[error("eFuse: Padding type mismatch")]
+    EfusePaddingTypeMismatch = 0xc004020D,
+
+    // Host commands
+    #[error("Host: Device control exception")]
+    DeviceCtrlException = 0xc0050001,
+    #[error("Host: Shutdown command exception")]
+    ShutdownCmdException = 0xc0050002,
+    #[error("Host: Download exception")]
+    DownloadException = 0xc0050003,
+    #[error("Host: Upload exception")]
+    UploadException = 0xc0050004,
+    #[error("Host: External RAM exception")]
+    ExtRamException = 0xc0050005,
+    #[error("Host: Notify switch USB speed exception")]
+    NotifySwitchUsbSpeedException = 0xc0050006,
+    #[error("Host: Read data exception")]
+    ReadDataException = 0xc0050007,
+    #[error("Host: Write data exception")]
+    WriteDataException = 0xc0050008,
+    #[error("Host: Format exception")]
+    FormatException = 0xc0050009,
+    #[error("Host: OTP operation exception")]
+    OtpOperationException = 0xc005000A,
+    #[error("Host: Switch USB exception")]
+    SwitchUsbException = 0xc005000B,
+    #[error("Host: Write eFuse exception")]
+    WriteEfuseException = 0xc005000C,
+    #[error("Host: Read eFuse exception")]
+    ReadEfuseException = 0xc005000D,
+
+    // BROM
+    #[error("BROM: Start command failed")]
+    BromStartCmdFailed = 0xc0060001,
+    #[error("BROM: Failed to get BBChip HW version")]
+    BromGetBbchipHwVerFailed = 0xc0060002,
+    #[error("BROM: Send DA command failed")]
+    BromCmdSendDaFailed = 0xc0060003,
+    #[error("BROM: Failed to jump to DA")]
+    BromCmdJumpDaFailed = 0xc0060004,
+    #[error("BROM: Command failed")]
+    BromCmdFailed = 0xc0060005,
+    #[error("BROM: Stage callback failed")]
+    BromStageCallbackFailed = 0xc0060006,
+
+    // DA section
+    #[error("DA: Version mismatch")]
+    DaVersionMismatch = 0xc0070001,
+    #[error("DA: Not found")]
+    DaNotFound = 0xc0070002,
+    #[error("DA: Section not found")]
+    DaSectionNotFound = 0xc0070003,
+    #[error("DA: Hash mismatch. DA2 hash does not match hash in DA1")]
+    DaHashMismatch = 0xc0070004,
+    #[error("DA: Exceeded maximum allowed number")]
+    DaExceedMaxNum = 0xc0070005,
+
+    #[error("Unknown error")]
+    Unknown = 0xffffffff,
+}
+
+#[derive(Debug, Error)]
+#[error("{kind} (code: {code:#010x})")]
+pub struct XFlashError {
+    pub kind: XFlashErrorKind,
+    pub code: u32,
+}
+
+impl XFlashError {
+    pub fn from_code(code: u32) -> Self {
+        let kind = XFlashErrorKind::try_from(code).unwrap_or(XFlashErrorKind::Unknown);
+        Self { kind, code }
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod connection;
 pub mod core;
 pub mod da;
+pub mod error;
 pub mod exploit;
 
 pub use connection::port::{MTKPort, find_mtk_port};


### PR DESCRIPTION
This adds custom errors to penumbra, as well as using them coherently throughout all the library.

Before this, some places used tokio Error, some used `std::io::Error`, as well as using `Result<()>` sometimes and `Result<(), Error>` other times.

Now all the library follows the same coherent error handling.

Closes #12 