### PR TITLE
tui: selectable_list component. Add indent after highlight_symbol

### DIFF
--- a/tui/src/components/selectable_list.rs
+++ b/tui/src/components/selectable_list.rs
@@ -5,14 +5,12 @@
  */
 
 use derive_builder::Builder;
-use ratatui::{
-    Frame,
-    layout::Rect,
-    style::{Color, Modifier, Style},
-    widgets::{Block, Borders, List, ListItem, ListState},
-};
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
 
-#[derive(Builder, Clone, Default, Debug)]
+#[derive(Builder, Clone, Default)]
 pub struct ListItemEntry {
     pub label: String,
     #[builder(default, setter(strip_option))]
@@ -33,7 +31,7 @@ pub struct SelectableList {
         s
     }")]
     pub state: ListState,
-    #[builder(default)]
+    #[builder(setter(custom))]
     pub highlight_symbol: String,
     #[builder(default)]
     pub toggled: bool,
@@ -46,15 +44,10 @@ impl SelectableList {
             .iter()
             .enumerate()
             .map(|(i, item)| {
-                let mut style = item
-                    .style
-                    .unwrap_or_else(|| Style::default().fg(Color::White));
+                let mut style = item.style.unwrap_or_else(|| Style::default().fg(Color::White));
 
                 if Some(i) == self.selected_index() {
-                    style = style
-                        .bg(Color::Gray)
-                        .fg(Color::Black)
-                        .add_modifier(Modifier::BOLD);
+                    style = style.bg(Color::Gray).fg(Color::Black).add_modifier(Modifier::BOLD);
                 }
 
                 let label = {
@@ -78,9 +71,7 @@ impl SelectableList {
 
         let block = Block::default().title(block_title).borders(Borders::ALL);
 
-        let list = List::new(list_items)
-            .block(block)
-            .highlight_symbol(&self.highlight_symbol);
+        let list = List::new(list_items).block(block).highlight_symbol(&self.highlight_symbol);
 
         f.render_stateful_widget(list, area, &mut self.state);
     }
@@ -118,8 +109,16 @@ impl SelectableList {
             }
         }
     }
+
     pub fn checked_items(&self) -> Vec<&ListItemEntry> {
         self.items.iter().filter(|item| item.toggle).collect()
+    }
+}
+
+impl SelectableListBuilder {
+    pub fn highlight_symbol(&mut self, s: impl Into<String>) -> &mut Self {
+        self.highlight_symbol = Some(format!("{} ", s.into().trim_end()));
+        self
     }
 }
 


### PR DESCRIPTION
## Summary
### Before
<img width="1138" height="621" alt="изображение" src="https://github.com/user-attachments/assets/019dc6d8-789d-4135-a9a4-d44c1986ae90" />

### After
<img width="1407" height="760" alt="изображение" src="https://github.com/user-attachments/assets/9d5b2c87-7214-4397-99dd-847c9897f0e1" />


## Checklist

<!-- Put an x inside [ ] to check the box -->

- [x] I have read the **CONTRIBUTING** document.

- [x] This PR changes something in the code (e.g. for better performance).
    - [x] If any code changes had taken place, I've tested them before committing.
- [ ] This PR adds something new.
- [ ] This PR fixes an issue. <!-- Please reference the issue -->
- [ ] This PR includes breaking changes.
- [ ] This PR is not code related (e.g. README, Documentation)
