### PR TITLE
core: Add more device VID/PID combinations

### DIFF
--- a/core/src/connection/port.rs
+++ b/core/src/connection/port.rs
@@ -10,10 +10,21 @@ use crate::error::Result;
 
 /// List of all ports available for connecting and what mode they refer to.
 /// Add more entries here for vendor specific ports
+#[rustfmt::skip]
 pub const KNOWN_PORTS: &[(u16, u16, ConnectionType)] = &[
-    (0x0E8D, 0x0003, ConnectionType::Brom), // Mediatek USB Port (BROM)
+    (0x0E8D, 0x0003, ConnectionType::Brom),      // Mediatek USB Port (BROM)
+    (0x0E8D, 0x6000, ConnectionType::Preloader), // Mediatek USB Port (Preloader)
     (0x0E8D, 0x2000, ConnectionType::Preloader), // Mediatek USB Port (Preloader)
-    (0x0E8D, 0x2001, ConnectionType::Da),   // Mediatek USB Port (DA)
+    (0x0E8D, 0x2001, ConnectionType::Da),        // Mediatek USB Port (DA)
+    (0x0E8D, 0x20FF, ConnectionType::Preloader), // Mediatek USB Port (Preloader)
+    (0x0E8D, 0x3000, ConnectionType::Preloader), // Mediatek USB Port (Preloader)
+    (0x1004, 0x6000, ConnectionType::Preloader), // LG USB Port (Preloader)
+    (0x22D9, 0x0006, ConnectionType::Preloader), // OPPO USB Port (Preloader)
+    (0x0FCE, 0xF200, ConnectionType::Brom),      // Sony USB Port (BROM)
+    (0x0FCE, 0xD1E9, ConnectionType::Brom),      // Sony USB Port (BROM XA1)
+    (0x0FCE, 0xD1E2, ConnectionType::Brom),      // Sony USB Port (BROM)
+    (0x0FCE, 0xD1EC, ConnectionType::Brom),      // Sony USB Port (BROM L1)
+    (0x0FCE, 0xD1DD, ConnectionType::Brom),      // Sony USB Port (BROM F3111)
 ];
 
 #[derive(Debug, PartialEq, Copy, Clone)]


### PR DESCRIPTION
## Summary

Some MTK devices use vendor-specific USB IDs instead of the standard MediaTek ones.

This PR adds support for Sony, OPPO, and LG devices plus a few more MediaTek PIDs that show up in the wild.

VID/PID list taken from MTKClient.

## Checklist

<!-- Put an x inside [ ] to check the box -->

- [x] I have read the **CONTRIBUTING** document.

- [x] This PR changes something in the code (e.g. for better performance).
    - [x] If any code changes had taken place, I've tested them before committing.
- [x] This PR adds something new.
- [ ] This PR fixes an issue. <!-- Please reference the issue -->
- [ ] This PR includes breaking changes.
- [ ] This PR is not code related (e.g. README, Documentation)
