### PR TITLE
docs: Add heapbait documentation

### DIFF
--- a/docs/content/Mediatek/Exploits/Heapbait.md
+++ b/docs/content/Mediatek/Exploits/Heapbait.md
@@ -1,0 +1,112 @@
+heapb8 (/ˈhiːpbeɪt/, "heap-bait") is a heap overflow exploit targeting MediaTek's second stage [[Download Agent]] (DA2). It allows loading unsigned code and bypassing security checks on devices that use the [[XML DA Protocol|V6]] and have been patched against [[Carbonara]].
+
+The exploit was originally discovered by the [Chimera Tool](https://chimeratool.com/) team and later reverse engineered and implemented into [[penumbra]] by [R0rt1z2](https://github.com/R0rt1z2) and [shomy](https://github.com/shomykohai).
+
+## How the Exploit Works
+heapb8 abuses a buffer overflow in DA2's USB file download handler (`fp_read_host_file`) to corrupt heap metadata and hijack the DA's DPC mechanism in order to redirect execution to arbitrary shellcode.
+
+This is accomplished through `CMD:SECURITY-SET-ALLINONE-SIGNATURE`, a command normally used to provide the DA with an "all-in-one" signature file containing cryptographic signatures for every partition on the device.
+
+The command accepts a filename via its XML argument, downloads the corresponding file from the host, and stores it in a global buffer for later use during flashing.
+
+### Stage 1
+The first command is sent with a normal filename. The file content is not a real signature, it's a shellcode payload, which gets allocated somewhere on the heap.
+
+> [!Note]
+> In [[penumbra]]'s implementation, the payload is preceded by a large NOP sled (~80MB) to avoid having to predict the exact heap address where the shellcode lands.
+
+### Stage 2
+A second command is sent with a ~5KB filename. When `mxmlLoadString` parses the command XML, it allocates a buffer for the filename string. Due to allocation sizing, this buffer lands immediately after the AIO2 data buffer in the heap:
+```
+[AIO1 shellcode buffer] ... [AIO2 data buffer (0x1400)] [XML filename buffer (0x13A0)]
+```
+
+### Stage 3
+The vulnerability is in `fp_read_host_file`. The host advertises an arbitrary size (e.g. `0x13FC` bytes), so the DA allocates a buffer based on that size plus 4 bytes of overhead (e.g. `0x1400` bytes).
+
+However, the read loop uses `packet_size` (`0x20000`) per chunk instead of the remaining capacity:
+```c
+do {
+    chunk_len = packet_size;  // always 0x20000, not remaining capacity.
+    status = (*channel->read)((uint8_t *)(buffer + bytes_received), &chunk_len);
+    bytes_received += chunk_len;
+} while (bytes_received != advertised_size);
+```
+
+By actually sending `0x1410` bytes, the DA overflows `0x10` bytes past the AIO2 buffer, corrupting the XML filename buffer's `alloc_struct_begin` header.
+
+### Stage 4
+On ARM64, the allocated chunk header immediately before user data looks like:
+```
++0x00: ptr   (8 bytes)  pointer to chunk start
++0x08: size  (8 bytes)  allocation size
++0x10: data             user data begins here
+```
+
+When `free()` is called on a chunk, it executes:
+```c
+ldp  x8, x9, [ptr, #-0x10] ; x8 = alloc.ptr, x9 = alloc.size
+str  x9, [x8, #0x10]       ; writes alloc.size to alloc.ptr + 0x10
+```
+
+By overwriting the header with:
+- `ptr = dpc_addr - 0x10` (pointing 16 bytes before `dpc->cb`)
+- `size = shellcode_addr`
+
+...the `free()` call writes `shellcode_addr` directly into `dpc->cb`.
+
+### Stage 5
+At the end of each command iteration, DA2's command loop checks for a pending Deferred Procedure Call:
+```c
+if (get_cmd_dpc()->cb != 0) {
+    get_cmd_dpc()->cb(get_cmd_dpc()->arg);
+}
+```
+
+The DPC structure lives at a fixed address in `.bss`. So, when the transfer is then aborted, `mxmlDelete` -> `free()` gets triggered on the filename buffer with the corrupted header, which causes the shellcode address to be written into `dpc->cb`.
+
+On the next command loop iteration, the shellcode executes.
+
+## Technical Details
+### Heap Layout
+DA2 uses a simple heap allocator based on [LK's miniheap](https://github.com/littlekernel/lk/blob/master/lib/heap/miniheap/miniheap.c). The heap is divided into chunks laid out sequentially in memory, each prefixed with a header.
+
+Free chunks are tracked via a doubly-linked list sorted by address:
+```c
+struct free_heap_chunk {
+    struct list_node node;  // prev / next pointers
+    size_t len;             // total size of this chunk
+};
+```
+
+Allocated chunks are not linked. They simply sit in memory with a header placed immediately before the user data:
+```c
+struct alloc_struct_begin {
+    void *ptr;    // pointer to the start of the chunk
+    size_t size;  // total size of the chunk (header + user data)
+};
+```
+
+When a chunk is freed, the allocator writes the chunk size back into the chunk and inserts it into the free list.
+
+This is the primitive heapb8 abuses. By corrupting the header of an allocated chunk before it gets freed, we control what gets written and where.
+
+### ARM32 vs ARM64
+V6 DAs can run in either ARM64 or ARM32 mode. The chunk header layout differs slightly:
+
+| Architecture | Header layout |
+|:---:|:---|
+| ARM64 | `ptr (8B)` \| `size (8B)` |
+| ARM32 | `magic (4B)` \| `ptr (4B)` \| `size (4B)` |
+
+The `magic` field (`0x68656170`, 'heap') is present only on ARM32 and ignored by `free()`, so it can be set to anything (penumbra uses `0xDEADBEEF`).
+
+## The Fix
+MediaTek patched the USB overflow in `fp_read_host_file` somewhere around November 2024 by correctly capping the read size to the remaining capacity:
+```c
+len = total_length - xfered;
+len = len >= package_len ? package_len : len;
+```
+
+> [!Note]
+> The exact date and the CVE ID for this vulnerability are unknown.


### PR DESCRIPTION
## Summary

This PR basically adds a small piece of documentation for the heapbait / heapb8 exploit. It should cover the basics needed to understand how the vulnerability works.

Note that I haven't included information about the payload (haku), since it isn't directly related to the vulnerability (i.e., the goal is simply to document the fundamentals).

## Checklist

- [x] I have read the **CONTRIBUTING** document.

- [ ] This PR changes something in the code (e.g. for better performance).
    - [ ] If any code changes had taken place, I've tested them before committing.
- [ ] This PR adds something new.
- [ ] This PR fixes an issue. <!-- Please reference the issue -->
- [ ] This PR includes breaking changes.
- [x] This PR is not code related (e.g. README, Documentation)
