### PR TITLE
core(xflash): Patch DA1/DA2 version anti-rollback

### DIFF
--- a/core/src/da/xflash/patch.rs
+++ b/core/src/da/xflash/patch.rs
@@ -47,7 +47,8 @@ pub fn patch_da(xflash: &mut XFlash) -> Result<DA> {
 
 /// Patches only DA1, specific for V5 DA
 pub fn patch_da1(xflash: &mut XFlash) -> Result<DAEntryRegion> {
-    let da1 = xflash.da.get_da1().cloned().unwrap();
+    let mut da1 = xflash.da.get_da1().cloned().unwrap();
+    patch_anti_rollback(&mut da1, "DA1")?;
     Ok(da1)
 }
 
@@ -66,7 +67,22 @@ pub fn patch_da2(xflash: &mut XFlash) -> Result<DAEntryRegion> {
 fn patch_security(da: &mut DAEntryRegion, analyzer: &Thumb2Analyzer) -> Result<bool> {
     patch_lock_state(da, analyzer)?;
     patch_sec_policy(da, analyzer)?;
+    patch_anti_rollback(da, "DA2")?;
     patch_da_sla(da, analyzer)
+}
+
+/// Disables the DA version anti-rollback check by overwriting the
+/// 0xC0020053 error constant in the DA's literal pool with 0, so the
+/// error-return path returns success and older DA versions are accepted.
+fn patch_anti_rollback(da: &mut DAEntryRegion, label: &str) -> Result<bool> {
+    let pos = find_pattern(&da.data, "530002C0", 0);
+    if pos == HEX_NOT_FOUND {
+        return Ok(false);
+    }
+
+    patch(&mut da.data, pos, "00000000")?;
+    info!("Patched {label} version anti-rollback.");
+    Ok(true)
 }
 
 fn patch_lock_state(da: &mut DAEntryRegion, analyzer: &Thumb2Analyzer) -> Result<bool> {


### PR DESCRIPTION
## Summary

<!-- Describe for what this PR is for.

Zero out the 0xC0020053 error constant in the literal pool of both DA1 and DA2 so the version anti-rollback check returns success instead of its error code. Required on devices where DA1 itself enforces ARB after sync (with SBC on, DA1's check fires before DA2 ever runs).   

If this PR closes an open issue, please reference it.
Prefix the title of the PR with either `tui:`, `core:`, or `docs:` depending on
which part of the codebase is affected.
If the PR is not code related, follow the style guide in the contributing document.

 -->

## Checklist

<!-- Put an x inside [ ] to check the box -->

- [X] I have read the **CONTRIBUTING** document.

- [x] This PR changes something in the code (e.g. for better performance).
    - [x] If any code changes had taken place, I've tested them before committing.
- [x] This PR adds something new.
- [ ] This PR fixes an issue. <!-- Please reference the issue -->
- [ ] This PR includes breaking changes.
- [ ] This PR is not code related (e.g. README, Documentation)
