### PR TITLE
tui: Fix invalid comments in read-all

### DIFF
--- a/tui/src/cli/commands/device/readall.rs
+++ b/tui/src/cli/commands/device/readall.rs
@@ -19,9 +19,9 @@ use crate::cli::state::PersistedDeviceState;
 
 #[derive(Args, Debug)]
 pub struct ReadAllArgs {
-    /// The partition to read
+    /// The directory where the read partitions will be saved
     pub output_dir: PathBuf,
-    /// The destination file
+    /// What to skip
     #[arg(long, short = 's', value_delimiter = ',')]
     pub skip: Vec<String>,
 }


### PR DESCRIPTION
## Summary

Just a small fix of the usage in `read-all`.

## Checklist

- [x] I have read the **CONTRIBUTING** document.
- [x] This PR is not code related (e.g. README, Documentation) (I guess?)
