### PR TITLE
Fix 32-bit overflow parsing eMMC/UFS storage sizes

### DIFF
--- a/core/src/core/storage/emmc.rs
+++ b/core/src/core/storage/emmc.rs
@@ -7,7 +7,7 @@ use wincode::{Deserialize, SchemaRead, SchemaWrite};
 
 use crate::core::storage::{PartitionKind, Storage, StorageType};
 use crate::error::{Error, Result};
-use crate::utilities::xml::{get_tag, get_tag_usize};
+use crate::utilities::xml::{get_tag, get_tag_u64, get_tag_usize};
 
 /// Represents eMMC storage information.
 #[derive(Debug, SchemaRead, SchemaWrite, Clone)]
@@ -156,14 +156,14 @@ impl EmmcStorage {
     pub fn from_xml_response(xml: &str) -> Result<Self> {
         let block_size = get_tag_usize(xml, "emmc/block_size")? as u32;
 
-        let boot1_size = get_tag_usize(xml, "emmc/boot1_size")? as u64;
-        let boot2_size = get_tag_usize(xml, "emmc/boot2_size")? as u64;
-        let rpmb_size = get_tag_usize(xml, "emmc/rpmb_size")? as u64;
-        let gp1_size = get_tag_usize(xml, "emmc/gp1_size")? as u64;
-        let gp2_size = get_tag_usize(xml, "emmc/gp2_size")? as u64;
-        let gp3_size = get_tag_usize(xml, "emmc/gp3_size")? as u64;
-        let gp4_size = get_tag_usize(xml, "emmc/gp4_size")? as u64;
-        let user_size = get_tag_usize(xml, "emmc/user_size")? as u64;
+        let boot1_size = get_tag_u64(xml, "emmc/boot1_size")?;
+        let boot2_size = get_tag_u64(xml, "emmc/boot2_size")?;
+        let rpmb_size = get_tag_u64(xml, "emmc/rpmb_size")?;
+        let gp1_size = get_tag_u64(xml, "emmc/gp1_size")?;
+        let gp2_size = get_tag_u64(xml, "emmc/gp2_size")?;
+        let gp3_size = get_tag_u64(xml, "emmc/gp3_size")?;
+        let gp4_size = get_tag_u64(xml, "emmc/gp4_size")?;
+        let user_size = get_tag_u64(xml, "emmc/user_size")?;
 
         let cid_str: String = get_tag(xml, "emmc/id")?;
         let mut cid = [0u8; 16];

--- a/core/src/core/storage/ufs.rs
+++ b/core/src/core/storage/ufs.rs
@@ -6,7 +6,7 @@ use wincode::{Deserialize, SchemaRead, SchemaWrite};
 
 use crate::core::storage::{PartitionKind, Storage, StorageType};
 use crate::error::{Error, Result};
-use crate::utilities::xml::{get_tag, get_tag_usize};
+use crate::utilities::xml::{get_tag, get_tag_u64, get_tag_usize};
 
 #[repr(C)]
 #[derive(Debug, SchemaRead, SchemaWrite, Clone)]
@@ -130,10 +130,10 @@ impl UfsStorage {
 
     pub fn from_xml_response(xml: &str) -> Result<Self> {
         let block_size = get_tag_usize(xml, "ufs/block_size")? as u32;
-        let lu0_size = get_tag_usize(xml, "ufs/lua0_size")? as u64;
-        let lu1_size = get_tag_usize(xml, "ufs/lua1_size")? as u64;
-        let lu2_size = get_tag_usize(xml, "ufs/lua2_size")? as u64;
-        let lu3_size = get_tag_usize(xml, "ufs/lua3_size").unwrap_or(0) as u64;
+        let lu0_size = get_tag_u64(xml, "ufs/lua0_size")?;
+        let lu1_size = get_tag_u64(xml, "ufs/lua1_size")?;
+        let lu2_size = get_tag_u64(xml, "ufs/lua2_size")?;
+        let lu3_size = get_tag_u64(xml, "ufs/lua3_size").unwrap_or(0);
 
         // Older devices use ufs_cid, newer ones use id
         let cid_str: String = get_tag(xml, "ufs/ufs_cid").or_else(|_| get_tag(xml, "ufs/id"))?;

--- a/core/src/da/xml/storage.rs
+++ b/core/src/da/xml/storage.rs
@@ -23,14 +23,16 @@ pub fn detect_storage(xml: &mut Xml) -> Option<StorageKind> {
     match storage_str.as_str() {
         "EMMC" => {
             debug!("eMMC storage detected.");
-            if let Ok(storage) = EmmcStorage::from_xml_response(&reponse) {
-                return Some(StorageKind::Emmc(storage));
+            match EmmcStorage::from_xml_response(&reponse) {
+                Ok(storage) => return Some(StorageKind::Emmc(storage)),
+                Err(e) => debug!("Failed to parse eMMC HW-INFO response: {e}\n{reponse}"),
             }
         }
         "UFS" => {
             debug!("UFS storage detected.");
-            if let Ok(storage) = UfsStorage::from_xml_response(&reponse) {
-                return Some(StorageKind::Ufs(storage));
+            match UfsStorage::from_xml_response(&reponse) {
+                Ok(storage) => return Some(StorageKind::Ufs(storage)),
+                Err(e) => debug!("Failed to parse UFS HW-INFO response: {e}\n{reponse}"),
             }
         }
         _ => {}

--- a/core/src/utilities/xml.rs
+++ b/core/src/utilities/xml.rs
@@ -42,3 +42,16 @@ pub fn get_tag_usize(xml: &str, path: &str) -> Result<usize> {
     usize::from_str_radix(trimmed, 16)
         .map_err(|_| Error::penumbra(format!("Failed to parse hex XML tag `{}`", path)))
 }
+
+/// Like [`get_tag_usize`], but always parses into a `u64`.
+///
+/// Storage capacity values (e.g. eMMC/UFS partition sizes) routinely exceed
+/// `u32::MAX` and must not be parsed as `usize` on 32-bit targets.
+pub fn get_tag_u64(xml: &str, path: &str) -> Result<u64> {
+    let raw_value: String = get_tag(xml, path)?;
+
+    let trimmed = raw_value.trim_start_matches("0x");
+
+    u64::from_str_radix(trimmed, 16)
+        .map_err(|_| Error::penumbra(format!("Failed to parse hex XML tag `{}`", path)))
+}

--- a/tui/src/cli/commands/device/download.rs
+++ b/tui/src/cli/commands/device/download.rs
@@ -74,7 +74,7 @@ impl DeviceCommand for DownloadArgs {
             dev.download(&part.name, file_size as usize, &mut reader, &mut progress_callback)
         {
             pb.abandon("Download failed!");
-            return Err(e)?;
+            Err(e)?;
         }
 
         info!("Download to partition '{}' completed.", part.name);

--- a/tui/src/cli/commands/device/erase.rs
+++ b/tui/src/cli/commands/device/erase.rs
@@ -54,7 +54,7 @@ impl DeviceCommand for EraseArgs {
             Ok(_) => {}
             Err(e) => {
                 pb.abandon("Erase failed!");
-                return Err(e)?;
+                Err(e)?;
             }
         };
 

--- a/tui/src/cli/commands/device/format.rs
+++ b/tui/src/cli/commands/device/format.rs
@@ -52,7 +52,7 @@ impl DeviceCommand for FormatArgs {
 
         if let Err(e) = dev.format(&part.name, &mut progress_callback) {
             pb.abandon("Format failed!");
-            return Err(e)?;
+            Err(e)?;
         }
 
         info!("Partition '{}' formatted.", part.name);

--- a/tui/src/cli/commands/device/peek.rs
+++ b/tui/src/cli/commands/device/peek.rs
@@ -62,7 +62,7 @@ impl DeviceCommand for PeekArgs {
             Ok(_) => {}
             Err(e) => {
                 pb.abandon("Read failed!");
-                return Err(e)?;
+                Err(e)?;
             }
         }
 

--- a/tui/src/cli/commands/device/poke.rs
+++ b/tui/src/cli/commands/device/poke.rs
@@ -69,7 +69,7 @@ impl DeviceCommand for PokeArgs {
             Ok(_) => {}
             Err(e) => {
                 pb.abandon("Write failed!");
-                return Err(e)?;
+                Err(e)?;
             }
         }
 

--- a/tui/src/cli/commands/device/readflash.rs
+++ b/tui/src/cli/commands/device/readflash.rs
@@ -63,7 +63,7 @@ impl DeviceCommand for ReadArgs {
             Ok(_) => {}
             Err(e) => {
                 pb.abandon("Read failed!");
-                return Err(e)?;
+                Err(e)?;
             }
         };
 

--- a/tui/src/cli/commands/device/readoffset.rs
+++ b/tui/src/cli/commands/device/readoffset.rs
@@ -70,7 +70,7 @@ impl DeviceCommand for ReadOffArgs {
             &mut progress_callback,
         ) {
             pb.abandon("Read failed!");
-            return Err(e)?;
+            Err(e)?;
         };
 
         writer.flush()?;

--- a/tui/src/cli/commands/device/upload.rs
+++ b/tui/src/cli/commands/device/upload.rs
@@ -64,7 +64,7 @@ impl DeviceCommand for UploadArgs {
             Ok(_) => {}
             Err(e) => {
                 pb.abandon("Upload failed!");
-                return Err(e)?;
+                Err(e)?;
             }
         };
 

--- a/tui/src/cli/commands/device/writeall.rs
+++ b/tui/src/cli/commands/device/writeall.rs
@@ -114,7 +114,7 @@ impl DeviceCommand for WriteAllArgs {
                 dev.download(&part.name, file_size as usize, &mut reader, &mut progress_callback)
             {
                 pb.abandon("Download failed!");
-                return Err(e)?;
+                Err(e)?;
             }
 
             info!("Download to partition '{}' completed.", part.name);

--- a/tui/src/cli/commands/device/writeflash.rs
+++ b/tui/src/cli/commands/device/writeflash.rs
@@ -66,7 +66,7 @@ impl DeviceCommand for WriteArgs {
 
         if let Err(e) = dev.write_partition(&part.name, &mut reader, &mut progress_callback) {
             pb.abandon("Write failed!");
-            return Err(e)?;
+            Err(e)?;
         }
 
         info!("Flash write completed, {:#X} bytes written.", total_size);

--- a/tui/src/cli/commands/device/writeoffset.rs
+++ b/tui/src/cli/commands/device/writeoffset.rs
@@ -71,7 +71,7 @@ impl DeviceCommand for WriteOffArgs {
             &mut progress_callback,
         ) {
             pb.abandon("Write failed!");
-            return Err(e)?;
+            Err(e)?;
         };
 
         info!("Flash write completed, {:#X} bytes written.", self.length);

--- a/tui/src/cli/helpers/device.rs
+++ b/tui/src/cli/helpers/device.rs
@@ -63,11 +63,10 @@ pub async fn setup_device(args: &CliArgs, state: &mut PersistedDeviceState) -> R
         .with_verbose(args.verbose)
         .with_usb_log_channel(usb_log_channel);
 
-    if usb_log_channel {
-        if let Some(device_log) = setup_file_logger(DA_LOG_FILE).await {
+    if usb_log_channel
+        && let Some(device_log) = setup_file_logger(DA_LOG_FILE).await {
             builder = builder.with_device_log(device_log);
         }
-    }
 
     builder = if let Some(da) = da_data {
         builder.with_da_data(da)


### PR DESCRIPTION
## Summary

Fixes a 32-bit build correctness bug: eMMC/UFS storage capacity fields sent by
the device (hex values that can exceed `u32::MAX`, e.g. UFS `lua2_size`) were
parsed as `usize`, which silently fails on 32-bit targets like
`i686-pc-windows-gnu` and leaves storage undetected. Added `get_tag_u64` for
pointer-width-independent parsing and switched all eMMC/UFS size fields to
use it. Also includes a `device.rs` doctest compile fix, a mechanical
`cargo clippy --fix` cleanup for the `antumbra` bin, and a clippy nursery
doc-comment fix, all needed to get a clean 32-bit build/lint.

Tested against real MediaTek hardware on a 32-bit (`i686-pc-windows-gnu`)
build — confirmed clean storage detection, partition table read, and
partition readback (verified byte-for-byte against an independent `dd` dump)
before this fix silently failed with empty storage/partition data.

## Checklist

- [ ] I have read the **CONTRIBUTING** document.

- [x] This PR changes something in the code (e.g. for better performance).
    - [x] If any code changes had taken place, I've tested them before committing.
- [ ] This PR adds something new.
- [ ] This PR fixes an issue. <!-- Please reference the issue -->
- [ ] This PR includes breaking changes.
- [ ] This PR is not code related (e.g. README, Documentation)