### PR TITLE
tui: Compile tui on macOS with libusb backend only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "antumbra"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-mtk"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "acon",
  "crc32fast",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "penumbra-mtk"
-version = "1.1.0"
+version = "2.0.0"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "antumbra"
-version = "1.1.0"
+version = "2.0.0"
 edition.workspace = true
 authors = ["Shomy <git@itssho.my>"]
 license.workspace = true

--- a/tui/res/arch/PKGBUILD
+++ b/tui/res/arch/PKGBUILD
@@ -1,6 +1,6 @@
 # PKGBUILD by hexman1999 (https://github.com/hexman1999)
 pkgname=antumbra-git
-pkgver=1.1.0.r64.gadc4dec
+pkgver=2.0.0.r64.gadc4dec
 pkgrel=1
 pkgdesc="🌘 MTK flash tool written in rust"
 arch=('x86_64' 'aarch64')

--- a/tui/src/cli/mod.rs
+++ b/tui/src/cli/mod.rs
@@ -43,10 +43,10 @@ pub struct CliArgs {
                 .map(|s| match s.to_lowercase().as_str() {
 
                     "auto" => PortBackend::Auto,
-                    #[cfg(not(target_os = "android"))]
+                    #[cfg(not(any(target_os = "macos", target_os = "android")))]
                     "usb" => PortBackend::Usb,
                     "libusb" => PortBackend::Libusb,
-                    #[cfg(not(target_os = "android"))]
+                    #[cfg(not(any(target_os = "macos", target_os = "android")))]
                     "serial" => PortBackend::Serial,
                     _ => PortBackend::Auto,
                 })


### PR DESCRIPTION
## Summary

`PortBackend::Usb/Serial` variants only exist when penumbra's `nusb`/`serial` features are enabled, but on macOS the tui build pulls penumbra with libusb backend only _(see tui/Cargo.toml)_.
The CLI `--backend` parser still referenced the missing variants, breaking the build on macOS.

```
➜  penumbra git:(main) cargo build
   Compiling antumbra v2.0.0 (/private/tmp/penumbra/tui)
warning: unused macro definition: `form_item`
   --> tui/src/macros.rs:149:14
    |
149 | macro_rules! form_item {
    |              ^^^^^^^^^
    |
    = note: `#[warn(unused_macros)]` (part of `#[warn(unused)]`) on by default

error[E0599]: no variant, associated function, or constant named `Usb` found for enum `PortBackend` in the current scope
  --> tui/src/cli/mod.rs:47:43
   |
47 |                     "usb" => PortBackend::Usb,
   |                                           ^^^ variant, associated function, or constant not found in `PortBackend`

error[E0599]: no variant, associated function, or constant named `Serial` found for enum `PortBackend` in the current scope
  --> tui/src/cli/mod.rs:50:46
   |
50 |                     "serial" => PortBackend::Serial,
   |                                              ^^^^^^ variant, associated function, or constant not found in `PortBackend`

For more information about this error, try `rustc --explain E0599`.
warning: `antumbra` (bin "antumbra") generated 1 warning
error: could not compile `antumbra` (bin "antumbra") due to 4 previous errors; 1 warning emitted
```

## Checklist

<!-- Put an x inside [ ] to check the box -->

- [x] I have read the **CONTRIBUTING** document.

- [ ] This PR changes something in the code (e.g. for better performance).
    - [ ] If any code changes had taken place, I've tested them before committing.
- [ ] This PR adds something new.
- [x] This PR fixes an issue. <!-- Please reference the issue -->
- [ ] This PR includes breaking changes.
- [ ] This PR is not code related (e.g. README, Documentation)
